### PR TITLE
Add logging to file

### DIFF
--- a/src/RagnaCustoms.App/App.config
+++ b/src/RagnaCustoms.App/App.config
@@ -7,4 +7,12 @@
     <add key="ApiKey" value="" />
     <add key="SendScoreAutomatically" value="True" />
   </appSettings>
+  <system.diagnostics>
+	<trace autoflush="true" indentsize="4">
+	  <listeners>
+		<add name="myListener" type="System.Diagnostics.TextWriterTraceListener" initializeData="ragnacustom.log" />
+		<remove name="Default" />
+	  </listeners>
+	</trace>
+  </system.diagnostics>
 </configuration>

--- a/src/RagnaCustoms.App/Services/SessionParser.cs
+++ b/src/RagnaCustoms.App/Services/SessionParser.cs
@@ -1,5 +1,6 @@
 ﻿using RagnaCustoms.Models;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -66,6 +67,7 @@ namespace RagnaCustoms.Services
                         var concatenatedHashs = string.Concat(filesHashs);
 
                         session.Song.Hash = ComputeMD5(concatenatedHashs);
+                        Trace.WriteLine($"{DateTime.Now} - New file - Hash: {session.Song.Hash}; File: {songDirectoryPath}");
                     }
                     else if (line.Contains(songScoreLineHint))
                     {
@@ -75,7 +77,7 @@ namespace RagnaCustoms.Services
                         session.Score = line.Substring(startIndex, endIndex - startIndex).Trim(new[] { ' ', '.' });
 
                         if (session.Song.Hash is null) continue;
-
+                        Trace.WriteLine($"{DateTime.Now} - New session - Hash: {session.Song.Hash}; Level: {session.Song.Level}; Score: {session.Score}");
                         OnNewSession?.Invoke(session);
                     }
 

--- a/src/RagnaCustoms.App/Services/SessionUploader.cs
+++ b/src/RagnaCustoms.App/Services/SessionUploader.cs
@@ -1,5 +1,6 @@
 ﻿using RagnaCustoms.Models;
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -30,11 +31,11 @@ namespace RagnaCustoms.Services
             var result = await client.PostAsJsonAsync(Uri, models);
             if (result.IsSuccessStatusCode)
             {
-                // TODO: Do something with the result
+                Trace.WriteLine($"{DateTime.Now} - Upload success - Hash: {sessions[0].Song.Hash}; Score: {sessions[0].Score}");
             }
             else
             {
-                // TODO: Do something with the result
+                Trace.WriteLine($"{DateTime.Now} - Upload error ({result.ReasonPhrase}) - Hash: { sessions[0].Song.Hash}; Score: {sessions[0].Score}");
             }
         }
     }


### PR DESCRIPTION
As discussed on Discord, here is a logging system for Ragnacutom.App. The log file is located at `%localappdata%\RagnaCustoms\RagnaCustoms.App\ragnacustom.log`

At the moment it only logs:
- New file: only used to make correspondance between a hash and a song
- New session: every new session identified within `ragnarock.log` file
- Upload status: in case of error, print the error status as string

Due to some limitation in my development environment I have not be able to test a clean install with the code, if you can you should probably test it.

Example of generated logs:
```
15/06/2021 22:08:04 - New file - Hash: 343d30a14dc512ed1df50701e8781f80; File: C:\Users\M3lon\Documents\Ragnarock\CustomSongs\UnderBlackFlagsWeMarch
15/06/2021 22:08:04 - New session - Hash: 343d30a14dc512ed1df50701e8781f80; Level: 7; Score: 520306.250000
15/06/2021 22:08:04 - New session - Hash: 343d30a14dc512ed1df50701e8781f80; Level: 7; Score: 536381.625000
15/06/2021 22:08:04 - Upload error (Bad Request) - Hash: 343d30a14dc512ed1df50701e8781f80; Score: 536381.625000
15/06/2021 22:08:04 - Upload error (Bad Request) - Hash: b256e7230982beabd161883c6c458ca1; Score: 378582.187500
15/06/2021 22:11:51 - Upload success - Hash: 343d30a14dc512ed1df50701e8781f80; Score: 536381.625000
15/06/2021 22:11:51 - Upload success - Hash: b627aa6eee7aa1d553dd77bfa9680bd4; Score: 489179.281250
```

Don't hesitate to ping me on Discord if you want to talk directly (in french or english)