### PR TITLE
reword help command

### DIFF
--- a/src/RagnaCustoms.App/Views/Commandes/BaseCommand.cs
+++ b/src/RagnaCustoms.App/Views/Commandes/BaseCommand.cs
@@ -24,7 +24,7 @@ namespace RagnaCustoms.App.Views.Commandes
             OnMessageReceivedArgs e
         )
         {
-            client.SendMessage(joinedChannel, $"You can propose custom maps to " + joinedChannel.Channel + " thanks to the command !rc {map_id} simply by clicking on the corresponding button on the site https://ragnacustoms.com/");
+            client.SendMessage(joinedChannel, $"You can propose custom maps to {joinedChannel.Channel} thanks to the command !rc [map_id] simply by clicking on the corresponding button on the site https://ragnacustoms.com/");
             return true;
         }
     }

--- a/src/RagnaCustoms.App/Views/Commandes/CancelCommand.cs
+++ b/src/RagnaCustoms.App/Views/Commandes/CancelCommand.cs
@@ -37,7 +37,7 @@ namespace RagnaCustoms.App.Views.Commandes
                     }
                     catch (Exception o_O)
                     {
-                        client.SendMessage(joinedChannel, $"No More song to remove");
+                        client.SendMessage(joinedChannel, "No More song to remove");
                     }
                 }
             }

--- a/src/RagnaCustoms.App/Views/Commandes/CloseQueue.cs
+++ b/src/RagnaCustoms.App/Views/Commandes/CloseQueue.cs
@@ -27,16 +27,16 @@ namespace RagnaCustoms.App.Views.Commandes
         {
             if (e.ChatMessage.UserType == TwitchLib.Client.Enums.UserType.Viewer)
             {
-                client.SendMessage(joinedChannel, $"Sorry only moderator can do that");
+                client.SendMessage(joinedChannel, "Sorry only moderator can do that");
             }
             if (me.QueueIsOpen)
             {
                 me.QueueIsOpen = false;
-                client.SendMessage(joinedChannel, $"Queue is now closed");
+                client.SendMessage(joinedChannel, "Queue is now closed");
             }
             else
             {
-                client.SendMessage(joinedChannel, $"Queue is already closes");
+                client.SendMessage(joinedChannel, "Queue is already closes");
             }            
             return true;
         }

--- a/src/RagnaCustoms.App/Views/Commandes/HelpCommand.cs
+++ b/src/RagnaCustoms.App/Views/Commandes/HelpCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Windows.Forms;
 using TwitchLib.Client;
 using TwitchLib.Client.Events;
@@ -24,8 +25,48 @@ namespace RagnaCustoms.App.Views.Commandes
             OnMessageReceivedArgs e
         )
         {
-            client.SendMessage(joinedChannel, "Help 1/2 : !rc help (this command), !rc [map_id] (download the map), !rc cancel (remove last song you request)");
-            client.SendMessage(joinedChannel, "Help 2/2 : !rc open (open queue), !rc close (close queue), !rc shift (remove first song in list), !rc queue (list of songs not played), !rc next (next song to play), !rc version (to know current version)");
+            var args = e.ChatMessage.Message.Split(' ');
+            if (args.Length >= 3)
+            {
+                var searshedCmd = args[2];
+                if (me.commandes.ContainsKey(searshedCmd))
+                {
+                    var commande = me.commandes[searshedCmd];
+                    client.SendMessage(joinedChannel, $"Commande {searshedCmd} ---> {commande.help()}");
+                }
+                else
+                {
+                    client.SendMessage(joinedChannel, "Cette commande n'existe pas, vérifiez le nom de la commande.");
+                }
+            }
+            else
+            {
+                var cmdList = new List<ICommandes>();
+                var stringCommandList = new List<String>();
+                var index = 0;
+                foreach (KeyValuePair<string,ICommandes> cmd in me.commandes)
+                {
+                    if (!cmdList.Contains(cmd.Value))
+                    {
+                        cmdList.Add(cmd.Value);
+                        if (stringCommandList[index].Length < 450)
+                        {
+                            if (stringCommandList[index].Length == 0) stringCommandList[index] += $"!rc {cmd.Key}";
+                            else stringCommandList[index] += $", !rc {cmd.Key}";
+                        }
+                        else
+                        {
+                            index++;
+                            stringCommandList[index] += $"!rc {cmd.Key}";
+                        }
+                    }
+                }
+                foreach (string s in stringCommandList)
+                {
+                    client.SendMessage(joinedChannel, $"Liste des commandes ---> {s}");
+                }
+                client.SendMessage(joinedChannel, "Pour voir la description complete d'une commande utiliser \"!rc help [nom_de_la_commande]\"");
+            }
             return true;
         }
     }

--- a/src/RagnaCustoms.App/Views/Commandes/HelpCommand.cs
+++ b/src/RagnaCustoms.App/Views/Commandes/HelpCommand.cs
@@ -44,20 +44,22 @@ namespace RagnaCustoms.App.Views.Commandes
                 var cmdList = new List<ICommandes>();
                 var stringCommandList = new List<String>();
                 var index = 0;
+                stringCommandList.Add("");
                 foreach (KeyValuePair<string,ICommandes> cmd in me.commandes)
                 {
                     if (!cmdList.Contains(cmd.Value))
                     {
                         cmdList.Add(cmd.Value);
-                        if (stringCommandList[index].Length < 450)
+                        if (stringCommandList[index].Length <= 450)
                         {
-                            if (stringCommandList[index].Length == 0) stringCommandList[index] += $"!rc {cmd.Key}";
-                            else stringCommandList[index] += $", !rc {cmd.Key}";
+                            if (stringCommandList[index].Length == 0) stringCommandList[index] = $"!rc {cmd.Key}";
+                            else stringCommandList[index] = $"{stringCommandList[index]}, !rc {cmd.Key}";
                         }
                         else
                         {
                             index++;
-                            stringCommandList[index] += $"!rc {cmd.Key}";
+                            stringCommandList.Add("");
+                            stringCommandList[index] = $"!rc {cmd.Key}";
                         }
                     }
                 }

--- a/src/RagnaCustoms.App/Views/Commandes/HelpCommand.cs
+++ b/src/RagnaCustoms.App/Views/Commandes/HelpCommand.cs
@@ -24,8 +24,8 @@ namespace RagnaCustoms.App.Views.Commandes
             OnMessageReceivedArgs e
         )
         {
-            client.SendMessage(joinedChannel, $"Help 1/2 : !rc help (this command), !rc {}song id} (download the map), !rc cancel (remove last song you request)");
-            client.SendMessage(joinedChannel, $"Help 2/2 : !rc open (open queue), !rc close (close queue), !rc shift (remove first song in list), !rc queue (list of songs not played), !rc next (next song to play), !rc version (to know current version)");
+            client.SendMessage(joinedChannel, "Help 1/2 : !rc help (this command), !rc [map_id] (download the map), !rc cancel (remove last song you request)");
+            client.SendMessage(joinedChannel, "Help 2/2 : !rc open (open queue), !rc close (close queue), !rc shift (remove first song in list), !rc queue (list of songs not played), !rc next (next song to play), !rc version (to know current version)");
             return true;
         }
     }

--- a/src/RagnaCustoms.App/Views/Commandes/HowToCommand.cs
+++ b/src/RagnaCustoms.App/Views/Commandes/HowToCommand.cs
@@ -24,7 +24,7 @@ namespace RagnaCustoms.App.Views.Commandes
             OnMessageReceivedArgs e
         )
         {
-            client.SendMessage(joinedChannel, $"Go to https://ragnacustoms.com, click on the twitch button to copy !rc [songid] and paste it here");
+            client.SendMessage(joinedChannel, "Go to https://ragnacustoms.com, click on the twitch button to copy !rc [songid] and paste it here");
             return true;
         }
     }

--- a/src/RagnaCustoms.App/Views/Commandes/NextCommand.cs
+++ b/src/RagnaCustoms.App/Views/Commandes/NextCommand.cs
@@ -24,14 +24,14 @@ namespace RagnaCustoms.App.Views.Commandes
             OnMessageReceivedArgs e
         )
         {
-            var song = me.songRequests.Rows[0].Cells["Song"].Value.ToString();
+            var song = me.songRequests?.Rows[0]?.Cells["Song"]?.Value?.ToString() ?? null;
             if (song != null)
             {
                 client.SendMessage(joinedChannel, $"Next song : {song} ");
             }
             else
             {
-                client.SendMessage(joinedChannel, $"End of the queue");
+                client.SendMessage(joinedChannel, "End of the queue");
             }
             return true;
         }

--- a/src/RagnaCustoms.App/Views/Commandes/OpenQueue.cs
+++ b/src/RagnaCustoms.App/Views/Commandes/OpenQueue.cs
@@ -27,16 +27,16 @@ namespace RagnaCustoms.App.Views.Commandes
         {
             if (e.ChatMessage.UserType == TwitchLib.Client.Enums.UserType.Viewer)
             {
-                client.SendMessage(joinedChannel, $"Sorry only moderator can do that");
+                client.SendMessage(joinedChannel, "Sorry only moderator can do that");
             }
             if (!me.QueueIsOpen)
             {
                 me.QueueIsOpen = true;
-                client.SendMessage(joinedChannel, $"Queue is now open");
+                client.SendMessage(joinedChannel, "Queue is now open");
             }
             else
             {
-                client.SendMessage(joinedChannel, $"Queue is already open");
+                client.SendMessage(joinedChannel, "Queue is already open");
             }            
             return true;
         }

--- a/src/RagnaCustoms.App/Views/Commandes/QueueCommand.cs
+++ b/src/RagnaCustoms.App/Views/Commandes/QueueCommand.cs
@@ -53,7 +53,7 @@ namespace RagnaCustoms.App.Views.Commandes
             Thread.Sleep(400);
             foreach (var songMessage in songs)
             {
-                client.SendMessage(joinedChannel, $"{songMessage}");
+                client.SendMessage(joinedChannel, songMessage);
             }
             return true;
         }

--- a/src/RagnaCustoms.App/Views/Commandes/ShiftCommand.cs
+++ b/src/RagnaCustoms.App/Views/Commandes/ShiftCommand.cs
@@ -34,21 +34,21 @@ namespace RagnaCustoms.App.Views.Commandes
                 try
                 {
                     me.RemoveAtSongRequestInList(0);
-                    client.SendMessage(joinedChannel, $"Song removed");
+                    client.SendMessage(joinedChannel, "Song removed");
 
-                    var sog = me.songRequests.Rows[0].Cells["Song"].Value.ToString();
+                    var sog = me.songRequests?.Rows[0]?.Cells["Song"]?.Value?.ToString() ?? null;
                     if (sog != null)
                     {
                         client.SendMessage(joinedChannel, $"Next song : {sog} ");
                     }
                     else
                     {
-                        client.SendMessage(joinedChannel, $"End of the queue");
+                        client.SendMessage(joinedChannel, "End of the queue");
                     }
                 }
                 catch (Exception O_o)
                 {
-                    client.SendMessage(joinedChannel, $"No More song to remove");
+                    client.SendMessage(joinedChannel, "No More song to remove");
                 }
             }
             return true;

--- a/src/RagnaCustoms.App/Views/TwitchBotForm.cs
+++ b/src/RagnaCustoms.App/Views/TwitchBotForm.cs
@@ -81,7 +81,7 @@ namespace RagnaCustoms.App.Views
         
         public bool QueueIsOpen = true;
 
-        private Dictionary<string, ICommandes> commandes = new Dictionary<string, ICommandes>();
+        public Dictionary<string, ICommandes> commandes = new Dictionary<string, ICommandes>();
 
         private void loadCommands()
         {

--- a/src/RagnaCustoms.App/Views/TwitchBotForm.cs
+++ b/src/RagnaCustoms.App/Views/TwitchBotForm.cs
@@ -162,18 +162,22 @@ namespace RagnaCustoms.App.Views
             }
             else
             {
-                var arg1 = command[1];
-                if (!commandes.ContainsKey(arg1))
+                new Thread(() => 
                 {
-                    addRequest(arg1, e);
-                    return;
-                }
-                var cmd = commandes[arg1];
-                var success = cmd.action(joinedChannel, prefix, TwitchClient, this, e);
-                if (!success)
-                {
-                    TwitchClient.SendMessage(joinedChannel, $"{prefixe}An error has occurred !");
-                }
+                    Thread.CurrentThread.IsBackground = true; 
+                    var arg1 = command[1];
+                    if (!commandes.ContainsKey(arg1))
+                    {
+                        addRequest(arg1, e);
+                        return;
+                    }
+                    var cmd = commandes[arg1];
+                    var success = cmd.action(joinedChannel, prefix, TwitchClient, this, e);
+                    if (!success)
+                    {
+                        TwitchClient.SendMessage(joinedChannel, $"{prefixe}An error has occurred !");
+                    }
+                }).Start();
             }
         }
 


### PR DESCRIPTION
Changements dans la commande help

- listage automatique des commandes (plus besoin de metre a jour la commande a chaques ajout de commandes)
- ajout de la possibilité d'ajouter en argument le nom d'une commande pour afficher l'aide de cette commande

Changements globaux : 

- retrait des "$" non utiles 
- fix des valeurs potentiellement null qui n'était pas gérer et pouvais causé une exception

- passage de la liste des commandes en publique (permet son accès depuis les commandes, utilisé dans le help)